### PR TITLE
[FIX] Switch to working Extension Builder version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "typo3/cms": "8.*",
-    "friendsoftypo3/extension-builder": "dev-master",
+    "friendsoftypo3/extension-builder": "8.7.x-dev",
     "helhum/typo3-console": "*"
   },
   "autoload": {


### PR DESCRIPTION
This version should work fine.

I can create models, relations and all the other stuff just fine, haven't encountered any errors while trying it out in the playground so far.